### PR TITLE
fix: gallery page change doesn't scroll with document

### DIFF
--- a/example/css/pd-modal.css
+++ b/example/css/pd-modal.css
@@ -185,20 +185,22 @@
 }
 
 .pd-modal__thumbnail-list {
+	position: relative;
 	display: flex;
+	gap: 1rem;
 	width: fit-content;
 	padding: 5px !important;
 	margin: 0 auto !important;
 	overflow-x: auto;
 	list-style-type: none !important;
-	gap: calc(1rem - 2 * 5px);
+	scroll-behavior: smooth;
 	-webkit-overflow-scrolling: touch;
 }
 
 .pd-modal__thumbnail-item {
 	flex: 0 0 auto;
-	margin: 0;
-	padding: 0;
+	margin: 0 !important;
+	padding: 0 !important;
 }
 
 .pd-modal__thumbnail-link {

--- a/example/index.html
+++ b/example/index.html
@@ -486,16 +486,6 @@ modal.registerContentLoader(new HTMLContentLoader())</code></pre>
 						<td><code>false</code></td>
 						<td>Displays thumbnail images along with text navigation</td>
 					</tr>
-					<tr>
-						<th scope="row" class="py-2 align-baseline"><code>thumbnailsAlignOnShow</code></th>
-						<td><code>ScrollIntoViewOptions</code></td>
-						<td><pre class="my-0 p-0"><code class="language-typescript">{
-	behavior: 'smooth',
-	block: 'nearest',
-	inline: 'center'
-}</code></pre></td>
-						<td>Object passed into <code>scrollIntoView</code> method called on page change.</td>
-					</tr>
 				</tbody>
 			</table>
 		</div>


### PR DESCRIPTION
`scrollIntoView` has been replaced with `scrollTo` implementation, because the former scrolls with the whole document if needed. Current implementation only scrolls with `.pd-modal__thumbnail-list` element while keeping the ability to scroll in both axis. Scroll behavior is always `'auto'`.

The `thumbnailsAlignOnShow` has been removed.