### PR TITLE
Media gallery loader spinner

### DIFF
--- a/example/css/pd-modal.css
+++ b/example/css/pd-modal.css
@@ -64,6 +64,14 @@
 	line-height: normal;
 }
 
+.pd-modal__spinner {
+	transition: opacity 150ms ease-out;
+}
+.pd-modal__spinner[hidden] {
+	opacity: 0;
+	pointer-events: none;
+}
+
 .pd-modal__header {
 	display: flex;
 	flex-wrap: wrap;

--- a/example/index.html
+++ b/example/index.html
@@ -570,8 +570,13 @@ modal.registerContentLoader(new HTMLContentLoader())</code></pre>
 		createScrollbarWidthStylesheet()
 
 		// Modal itself
+		const spinner = document.createElement('div');
+		spinner.classList.add('pd-modal__spinner', 'absolute', 'inset-0', 'bg-white/80', 'grid', 'place-content-center', 'text-lg', 'font-bold')
+		spinner.innerHTML = 'Načítám&hellip;'
+
 		const modal = new PdModal.create({
-			className: 'prose'
+			className: 'prose',
+			spinner: spinner
 		})
 		modal.registerContentLoader(new PdModal.HTMLContentLoader());
 		modal.registerContentLoader(new PdModal.MediaGalleryContentLoader({

--- a/example/index.html
+++ b/example/index.html
@@ -469,6 +469,12 @@ modal.registerContentLoader(new HTMLContentLoader())</code></pre>
 						<td>Allows you to add custom language or override existing ones. By default, the plugin supports <code>en</code>, <code>de</code>, <code>cs</code> and <code>sk</code>.</td>
 					</tr>
 					<tr>
+						<th scope="row" class="py-2 align-baseline"><code>immediateMediaReplace</code></th>
+						<td><code>boolean</code></td>
+						<td><code>false</code></td>
+						<td>When the page is changed in modal, the currently visible image is not replaced by the new one until the new one has fully loaded. Images can be replaced immediately by setting this option to <code>true</code> - this allows you to take advantage of progressive jpeg loading, for example, and show the progress of the image loading.</td>
+					</tr>
+					<tr>
 						<th scope="row" class="py-2 align-baseline"><code>infinitePager</code></th>
 						<td><code>boolean</code></td>
 						<td><code>false</code></td>

--- a/src/contentLoaders/MediaGalleryContentLoader.tsx
+++ b/src/contentLoaders/MediaGalleryContentLoader.tsx
@@ -25,6 +25,7 @@ type Relation = {
 	pagesSummary?: HTMLElement
 	prev?: HTMLAnchorElement
 	next?: HTMLAnchorElement
+	spinner?: Element
 	relatedOpeners: HTMLAnchorElement[]
 	activeIndex: number
 	title: string
@@ -111,8 +112,12 @@ export class MediaGalleryContentLoader implements ContentLoader {
 		const pagerElement = this.createPager()
 		this.relation.thumbnailsList = this.createThumbnails()
 
+		this.relation.spinner = modal.options.spinner
+
 		modal.content.replaceChildren(
-			...([pagerElement, mediaElement, this.relation.thumbnailsList].filter((item) => item !== null) as HTMLElement[])
+			...([pagerElement, mediaElement, this.relation.thumbnailsList, this.relation.spinner].filter(
+				(item) => item !== null
+			) as HTMLElement[])
 		)
 
 		this.setActivePage(this.relation.relatedOpeners.findIndex((opener) => opener.href === openerAnchor.href))
@@ -292,6 +297,7 @@ export class MediaGalleryContentLoader implements ContentLoader {
 		}
 
 		relation.modal.element.dataset.modalLoading = 'true'
+		relation.spinner?.removeAttribute('hidden')
 
 		this.setActivePage(index)
 		this.updateMediaElement(opener)
@@ -392,6 +398,7 @@ export class MediaGalleryContentLoader implements ContentLoader {
 			'load',
 			(event: Event) => {
 				this.relation?.modal.dispatchLoadEvent(opener, event)
+				this.relation?.spinner?.setAttribute('hidden', 'hidden')
 			},
 			{ once: true }
 		)


### PR DESCRIPTION
- [feat: MediaGalleryContentLoader now uses spinner property from `PdModal`](https://github.com/peckadesign/pd-modal/pull/6/commits/f387003ad694c146ae1a2d19d754a7308f01ea4e)
  If `PdModal` has a `spinner` property set, its value will be used for a spinner element when loading media.
- [feat: on page change, the image is not replaced until it has fully loaded](https://github.com/peckadesign/pd-modal/pull/6/commits/4f708da8f8a7fa2b2087322bb728e16158b31b9b)
   When the page is changed in modal, the currently visible image is not replaced by the new one until the new one has fully loaded. Images can be replaced immediately by setting the `immediateMediaReplace` option to `true` - this allows you to take advantage of progressive jpeg loading, for example, and show the progress of the image