### PR TITLE
feat: `BaseContentLoader` class added and `ContentLoader` interface changed

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -72,7 +72,7 @@
 		<pre><code class="language-typescript">import { PdModal, HTMLContentLoader } from '@peckadesign/pd-modal'
 
 const modal = new PdModal()
-modal.registerContentLoader(new HTMLContentLoader())</code></pre>
+modal.registerContentLoader(new HTMLContentLoader(modal))</code></pre>
 
 
 		<p>This code will create instance of a modal window. The content itself is loaded using <a href="#content-loaders">content loaders</a>. This allows you to import only loaders you actually need in your project.</p>
@@ -409,14 +409,15 @@ modal.registerContentLoader(new HTMLContentLoader())</code></pre>
 		</div>
 
 		<h2 id="content-loaders">Content loaders</h2>
-		<p>Content loading is done using ContentLoader classes. You can use those provided in this package or create your own. Whenever the <code>open</code> is called, PdModal tries to find appropriate loader. This is handled by <code>matcher</code> methods in each loader. The first content loader whose <code>matcher</code> method returns true is used.</p>
+		<p>Content loading is done using <code>ContentLoader</code> classes. You can use those provided in this package or create your own. Whenever the <code>open</code> is called, PdModal tries to find appropriate loader. This is handled by <code>matcher</code> methods in each loader. The first content loader whose <code>matcher</code> method returns true is used.</p>
+		<p>All content loaders provided with package extends <code>BaseContentLoader</code>, which sets up <code>modal: PdModal</code> property for the class. This property is then accessible by all methods within the content loader. The modal instance is passed to the constructor of each loader.</p>
 		<pre class="!max-w-none"><code class="language-typescript">export interface ContentLoader {
 	classList?: string[]                                            // default classes applied to modal element when the loader is used, removed when other loader is matched
 	listeners?: ContentLoaderListener&lt;keyof HTMLElementEventMap&gt;[]  // default event listeners applied to modal element when the loader is used, removed when other loader is matched
 	matcher: (opener: PdModalOpener) => boolean                     // returns whether loader should be used for the passed opener
 	isAsync: (opener: PdModalOpener) => boolean                     // returns whether the loading is async
-	openContent: (modal: PdModal, opener: PdModalOpener) => boolean // returns whether the content has been loaded yet
-	autoBind?: (modal: PdModal) => void                             // if `autoBind` option is true, this method is called upon loader registration
+	openContent: (opener: PdModalOpener) => boolean                 // returns whether the content has been loaded yet
+	autoBind?: () => void                                           // if `autoBind` option is true, this method is called upon loader registration
 }</code></pre>
 
 		<h3 id="HTMLContentLoader">HTMLContentLoader</h3>
@@ -499,7 +500,6 @@ modal.registerContentLoader(new HTMLContentLoader())</code></pre>
 						<th scope="row" class="py-2 align-baseline"><code>sizes</code></th>
 						<td><pre class="my-0 p-0"><code class="language-typescript">((
 	this: MediaGalleryContentLoader,
-	modal: PdModal,
 	opener: HTMLAnchorElement
 ) => string) | string | undefined</code></pre></td>
 						<td><code>undefined</code></td>
@@ -516,7 +516,7 @@ modal.registerContentLoader(new HTMLContentLoader())</code></pre>
 		</div>
 
 		<h3>Creating custom loader</h3>
-		<p>Custom content loader must implement interface <code>ContentLoader</code> mentioned above. Below you can see its properties in more depth.</p>
+		<p>When creating custom content loaders, it is recommended that you extend the <code>BaseContentLoader</code> to set the <code>modal</code> property in your loader. Custom content loader must implement interface <code>ContentLoader</code> mentioned above. Below you can see its properties in more depth.</p>
 
 		<h4 class="text-lg"><code>classList?: string[]</code></h4>
 		<p>This array of strings allows you to specify CSS classes that are added to the modal element (<code>.pd-modal</code>) when your loader is used. These classes are removed, when another loader is used.</p>
@@ -529,7 +529,9 @@ modal.registerContentLoader(new HTMLContentLoader())</code></pre>
 	listener: (event: HTMLElementEventMap[T]) => void
 }</code></pre>
 		<p>Example usage (as used in <code>MediaGalleryContentLoader</code>) in loader constructor:</p>
-		<pre><code class="language-typescript">public constructor(options?: Partial&lt;PdModalMediaOptions&gt;) {
+		<pre><code class="language-typescript">public constructor(modal: PdModal, options?: Partial&lt;PdModalMediaOptions&gt;) {
+	super(modal)
+
 	const keyupListener: ContentLoaderListener&lt;'keyup'&gt; = {
 		eventName: 'keyup',
 		listener: this.handleKeyUp.bind(this)
@@ -546,13 +548,13 @@ modal.registerContentLoader(new HTMLContentLoader())</code></pre>
 		<p>This method should return whether the content being loaded is async or not. In practise, this affects when the options (listeners, classes, width, etc.) from opener element are applied. If <code>true</code> is returned, then those options are applied immediatelly after modal has been opened (after <code>beforeOpen</code> event has been called and after the modal element has been connected to the DOM). If <code>false</code> is returned, then it is content loader responsibility to apply these options &ndash; public method <code>PdModal.setOptionsFromOpener()</code> is available. This allows you to affect the exact moment, when options are applied. E.g. you might want to delay the change of modal appearance (using width or classes) only to happen after the AJAX content has been loaded. See <code>PdModalNajaAdapter</code>.</p>
 		<p>On the other hand, e.g. <code>MediaGalleryContentLoader</code> returns <code>true</code> in this method, even though the content isn't preloaded and thus is yet to be loaded. That is because all other content (paging, thumbnails, etc.) is inserted immediately (or at least its DOM structure is).</p>
 
-		<h4 class="text-lg"><code>openContent: (modal: PdModal, opener: PdModalOpener) => boolean</code></h4>
-		<p>This method is called when the content loader has been matched. You should prepare your content in this method and append it the <code>modal.content</code> element. You can also modify the modal title using <code>PdModal.setModaltitle(title: string)</code> method.</p>
+		<h4 class="text-lg"><code>openContent: (opener: PdModalOpener) => boolean</code></h4>
+		<p>This method is called when the content loader has been matched. You should prepare your content in this method and append it to the <code>PdModal.content</code> (PdModal instance is accessible via <code>this.modal</code> property) element. You can also modify the modal title using <code>PdModal.setModaltitle(title: string)</code> method.</p>
 		<p>The return value of this method affects when the load event is dispatched. If <code>true</code> is returned, then the <code>PdModal</code> dispatches the <code>load</code> event after this method finishes. If <code>false</code> is returned, you must dispatch the <code>load</code> yourself programatically using the <code>PdModal.dispatchLoadEvent(opener: PdModalOpener, event: Event)</code> method. For more information, see the <code>MediaGalleryContentLoader</code>, where this event is dispatched after the image (iframe) is fully loaded.</p>
 
 		<h4 class="text-lg">
 			<span class="inline-block py-1 px-3 bg-blue-200 rounded-full text-sm">Experimental</span>
-			<code>autoBind?: (modal: PdModal) => void</code>
+			<code>autoBind?: () => void</code>
 		</h4>
 		<p>You can use this method to auto bind some classes to trigger modal opening. It is called for all content loaders in the time of their registration. This can be turned off by setting <code>autoBind: false</code> to <code>PdModal</code> itself. Currently, only the <code>HTMLContentLoader</code> has this method implemented, and it binds the opening to general <code>.js-modal</code> selector. This is not ideal and might change in the future implementation, thus marked as experimental.</p>
 	</div>
@@ -603,8 +605,8 @@ modal.registerContentLoader(new HTMLContentLoader())</code></pre>
 			className: 'prose',
 			spinner: spinner
 		})
-		modal.registerContentLoader(new PdModal.HTMLContentLoader());
-		modal.registerContentLoader(new PdModal.MediaGalleryContentLoader({
+		modal.registerContentLoader(new PdModal.HTMLContentLoader(modal));
+		modal.registerContentLoader(new PdModal.MediaGalleryContentLoader(modal, {
 			thumbnails: true,
 			sizes:
 				'(min-width: 964px) 900px,' +

--- a/src/PdModal.tsx
+++ b/src/PdModal.tsx
@@ -24,8 +24,8 @@ export interface ContentLoader {
 	listeners?: ContentLoaderListener<keyof HTMLElementEventMap>[]
 	matcher: (opener: PdModalOpener) => boolean
 	isAsync: (opener: PdModalOpener) => boolean
-	openContent: (modal: PdModal, opener: PdModalOpener) => boolean
-	autoBind?: (modal: PdModal) => void
+	openContent: (opener: PdModalOpener) => boolean
+	autoBind?: () => void
 }
 
 export type ContentLoaderListener<T extends keyof HTMLElementEventMap> = {
@@ -139,7 +139,7 @@ export class PdModal extends EventTarget {
 		this.contentLoaders.push(contentLoader)
 
 		if (this.options.autoBind && contentLoader.autoBind) {
-			contentLoader.autoBind(this)
+			contentLoader.autoBind()
 		}
 	}
 
@@ -184,7 +184,7 @@ export class PdModal extends EventTarget {
 		if (!isAsyncContent || !alreadyOpen) {
 			this.setOptionsFromOpener()
 			this.setOptionsFromContentLoader(contentLoader)
-			loaded = contentLoader.openContent(this, opener)
+			loaded = contentLoader.openContent(opener)
 		}
 
 		if (!loaded) {

--- a/src/contentLoaders/BaseContentLoader.ts
+++ b/src/contentLoaders/BaseContentLoader.ts
@@ -1,0 +1,9 @@
+import { PdModal } from '../PdModal'
+
+export class BaseContentLoader {
+	protected modal: PdModal
+
+	public constructor(modal: PdModal) {
+		this.modal = modal
+	}
+}

--- a/src/contentLoaders/HTMLContentLoader.ts
+++ b/src/contentLoaders/HTMLContentLoader.ts
@@ -1,6 +1,7 @@
 import { ContentLoader, PdModal, PdModalOpener } from '../PdModal'
+import { BaseContentLoader } from './BaseContentLoader'
 
-export class HTMLContentLoader implements ContentLoader {
+export class HTMLContentLoader extends BaseContentLoader implements ContentLoader {
 	public matcher(opener: PdModalOpener): boolean {
 		return opener !== null && this.getHash(opener) !== undefined
 	}
@@ -9,7 +10,7 @@ export class HTMLContentLoader implements ContentLoader {
 		return false
 	}
 
-	public openContent(modal: PdModal, opener: PdModalOpener): boolean {
+	public openContent(opener: PdModalOpener): boolean {
 		// This method is called only when matcher return true, therefore `opener` is always non-null and `hash` is
 		// always a string
 		const nonNullOpener = opener as NonNullable<PdModalOpener>
@@ -18,30 +19,30 @@ export class HTMLContentLoader implements ContentLoader {
 		const contentElement: HTMLElement | null = document.getElementById(hash)
 
 		if (contentElement) {
-			modal.content.innerHTML = contentElement.innerHTML
+			this.modal.content.innerHTML = contentElement.innerHTML
 		}
 
-		const title = this.getModalTitle(modal, nonNullOpener)
-		modal.setModaltitle(title)
+		const title = this.getModalTitle(this.modal, nonNullOpener)
+		this.modal.setModaltitle(title)
 
 		return true
 	}
 
-	public autoBind(modal: PdModal): void {
+	public autoBind(): void {
 		document.addEventListener('click', (event) => {
 			const targetNew = event.button || event.ctrlKey || event.shiftKey || event.altKey || event.metaKey
 			const element = event.target as Element
 			let opener = null
 
-			if (element && element.matches(modal.options.selector)) {
+			if (element && element.matches(this.modal.options.selector)) {
 				opener = element as HTMLElement | SVGElement
 			} else {
-				opener = element.closest<HTMLElement | SVGElement>(modal.options.selector)
+				opener = element.closest<HTMLElement | SVGElement>(this.modal.options.selector)
 			}
 
 			if (opener && (this.getHash(opener) || !targetNew)) {
 				event.preventDefault()
-				modal.open(opener, event)
+				this.modal.open(opener, event)
 			}
 		})
 	}

--- a/src/contentLoaders/NajaContentLoader.ts
+++ b/src/contentLoaders/NajaContentLoader.ts
@@ -1,6 +1,7 @@
-import { ContentLoader, PdModal, PdModalOpener } from '../PdModal'
+import { ContentLoader, PdModalOpener } from '../PdModal'
+import { BaseContentLoader } from './BaseContentLoader'
 
-export class NajaContentLoader implements ContentLoader {
+export class NajaContentLoader extends BaseContentLoader implements ContentLoader {
 	public matcher(opener: PdModalOpener): boolean {
 		return opener === null || opener.dataset.najaModal !== undefined
 	}
@@ -9,13 +10,14 @@ export class NajaContentLoader implements ContentLoader {
 		return true
 	}
 
-	public openContent(modal: PdModal): boolean {
-		if (modal.options.spinner) {
-			modal.content.replaceChildren(modal.options.spinner)
+	public openContent(): boolean {
+		if (this.modal.options.spinner) {
+			this.modal.content.replaceChildren(this.modal.options.spinner)
 		}
 
-		modal.title.innerHTML = modal.i18n[modal.options.language].loading
-		modal.title.hidden = false
+		this.modal.title.innerHTML = this.modal.i18n[this.modal.options.language].loading
+		this.modal.title.dataset.contentLoading = 'true'
+		this.modal.title.hidden = false
 
 		return false
 	}

--- a/src/index.esm.ts
+++ b/src/index.esm.ts
@@ -1,3 +1,4 @@
+export { BaseContentLoader } from './contentLoaders/BaseContentLoader'
 export { HTMLContentLoader } from './contentLoaders/HTMLContentLoader'
 export { MediaGalleryContentLoader } from './contentLoaders/MediaGalleryContentLoader'
 export { NajaContentLoader } from './contentLoaders/NajaContentLoader'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { BaseContentLoader } from './contentLoaders/BaseContentLoader'
 export { HTMLContentLoader } from './contentLoaders/HTMLContentLoader'
 export { MediaGalleryContentLoader } from './contentLoaders/MediaGalleryContentLoader'
 export { NajaContentLoader } from './contentLoaders/NajaContentLoader'


### PR DESCRIPTION
The `BaseContentLoader` class has been added and all loaders now extend it. This class adds a protected `modal` property to all loaders. No method of the `ContentLoader` interface now has a `modal` as a parameter. These methods should use the above property instead.