### PR TITLE
feat: `NajaContentLoader` matcher function changed

### DIFF
--- a/src/PdModalNajaAdapter.ts
+++ b/src/PdModalNajaAdapter.ts
@@ -43,6 +43,10 @@ export class PdModalNajaAdapter implements AjaxModal {
 	}
 
 	public dispatchLoad(options: PdModalAjaxOptions, event: Event): void {
+		if (this.pdModal.title.innerHTML !== this.pdModal.i18n[this.pdModal.options.language].loading) {
+			delete this.pdModal.title.dataset.contentLoading
+		}
+
 		this.pdModal.dispatchLoadEvent(this.getOpenerFromOptions(options), event)
 	}
 

--- a/src/contentLoaders/NajaContentLoader.ts
+++ b/src/contentLoaders/NajaContentLoader.ts
@@ -3,7 +3,11 @@ import { BaseContentLoader } from './BaseContentLoader'
 
 export class NajaContentLoader extends BaseContentLoader implements ContentLoader {
 	public matcher(opener: PdModalOpener): boolean {
-		return opener === null || opener.dataset.najaModal !== undefined
+		return (
+			opener === null ||
+			opener.dataset.najaModal !== undefined ||
+			(opener.classList.contains('ajax') && this.modal.isOpen)
+		)
 	}
 
 	public isAsync(): boolean {


### PR DESCRIPTION
`NajaContentLoader` is now used under the same conditions as the `AjaxModalExtension` for Naja itself. Previously it was necessary to use `data-naja-modal` to trigger this content loader. But the Naja extension itself is used even without this attribute, if there is a class `ajax` on the interacted element and the modal is already opened. The `NajaContentLoader` now adds the same conditions to be consistent and easy to use. This also makes it easier to e.g. enable loading inside modal only if already opened - now you just need to add the `ajax` class to the interacted element.

The content loader also adds a data attribute `data-content-loading` to the title element when using the default loading title. This makes it easier to style the loading state when there is no relevant content yet.