### PR TITLE
fix: `NajaContentLoader` matcher works when navigating browser history

### DIFF
--- a/src/contentLoaders/NajaContentLoader.ts
+++ b/src/contentLoaders/NajaContentLoader.ts
@@ -6,7 +6,7 @@ export class NajaContentLoader extends BaseContentLoader implements ContentLoade
 		return (
 			opener === null ||
 			opener.dataset.najaModal !== undefined ||
-			(opener.classList.contains('ajax') && this.modal.isOpen)
+			(opener.classList.contains('ajax') && (this.modal.isOpen || history.state?.pdModal))
 		)
 	}
 


### PR DESCRIPTION
Fixed the condition for matching `NajaContentLoader` when no `data-naja-modal` attribute is present. The loader should match not only when the modal is already open, but also when `history.state.pdModal` is present. This ensures that the content loader is matched even when navigating through the browser history.