### PR TITLE
feat: `NajaContentLoader` can be used with ajax forms

### DIFF
--- a/src/contentLoaders/NajaContentLoader.ts
+++ b/src/contentLoaders/NajaContentLoader.ts
@@ -3,10 +3,13 @@ import { BaseContentLoader } from './BaseContentLoader'
 
 export class NajaContentLoader extends BaseContentLoader implements ContentLoader {
 	public matcher(opener: PdModalOpener): boolean {
+		const form = (opener as HTMLButtonElement).form
+
 		return (
 			opener === null ||
 			opener.dataset.najaModal !== undefined ||
-			(opener.classList.contains('ajax') && (this.modal.isOpen || history.state?.pdModal))
+			(opener.classList.contains('ajax') && (this.modal.isOpen || history.state?.pdModal)) ||
+			(form && form.classList.contains('ajax') && form.dataset.najaModal !== undefined)
 		)
 	}
 


### PR DESCRIPTION
The `NajaContentLoader` matcher also checks for an opener.form element. If it is not `null` and has `ajax` class and `data-naja-modal`, this content loader is used.