### PR TITLE
fix: Prevent default called when handling closer click

### DIFF
--- a/src/PdModal.tsx
+++ b/src/PdModal.tsx
@@ -465,6 +465,7 @@ export class PdModal extends EventTarget {
 	}
 
 	private handleCloserClick(event: Event): void {
+		event.preventDefault()
 		this.close(event)
 	}
 

--- a/src/contentLoaders/MediaGalleryContentLoader.tsx
+++ b/src/contentLoaders/MediaGalleryContentLoader.tsx
@@ -150,7 +150,7 @@ export class MediaGalleryContentLoader extends BaseContentLoader implements Cont
 		document
 			.querySelectorAll<HTMLAnchorElement>(`${selector}[data-modal-related="${opener.dataset.modalRelated}"]`)
 			.forEach((opener) => {
-				// Prevent duplicities in related hrefs, only first occurence is stored
+				// Prevent duplicities in related hrefs, only first occurrence is stored
 				if (!relatedOpeners.find((rel) => rel.href === opener.href)) {
 					relatedOpeners.push(opener)
 				}


### PR DESCRIPTION
When the content closer is clicked, the prevent default is correctly called. This allows the element to be a link, but only the modal is closed. This will allow the same element markup to be used outside of the modal (e.g. if no JS is enabled or the modal content opens in a new window).