### PR TITLE
feature: Introduced `data-modal-empty` state

### DIFF
--- a/src/PdModal.tsx
+++ b/src/PdModal.tsx
@@ -128,7 +128,10 @@ export class PdModal extends EventTarget {
 
 		this.addEventListener('load', this.checkScrollbars.bind(this))
 		this.addEventListener('load', this.addClosersFromContent.bind(this))
-		this.addEventListener('load', () => delete this.element.dataset.modalLoading)
+		this.addEventListener('load', () => {
+			delete this.element.dataset.modalLoading
+			delete this.element.dataset.modalEmpty
+		})
 
 		this.a11yDialog.on('hide', (node, event) => this.dialogOnHide(event))
 
@@ -197,6 +200,10 @@ export class PdModal extends EventTarget {
 
 		if (!loaded) {
 			this.element.dataset.modalLoading = 'true'
+		}
+
+		if (!loaded && isAsyncContent && !alreadyOpen) {
+			this.element.dataset.modalEmpty = 'true'
 		}
 
 		if (!alreadyOpen) {


### PR DESCRIPTION
When the modal with async content is opened and loading for the first time, the `data-modal-empty` attribute is set along with the `data-modal-loading`. When navigating within the modal using ajax, only `data-modal-loading` is set again, not `data-modal-empty`. This allows loading states to be distinguished, whether there is actual content or not.