### PR TITLE
feature: `registercontentLoader` returns `ContentLoader`

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -310,8 +310,8 @@ modal.registerContentLoader(new HTMLContentLoader(modal))</code></pre>
 				</thead>
 				<tbody>
 					<tr>
-						<th scope="row" class="py-2 align-baseline"><pre class="p-0"><code class="language-typescript">registerContentLoader(contentLoader: ContentLoader): void</code></pre></th>
-						<td>This method registers new content loader for a modal window. Recieves instance of class which must implement <code>ContentLoader</code> interface.</td>
+						<th scope="row" class="py-2 align-baseline"><pre class="p-0"><code class="language-typescript">registerContentLoader(contentLoader: ContentLoader): ContentLoader</code></pre></th>
+						<td>This method registers new content loader for a modal window. Recieves instance of class which must implement <code>ContentLoader</code> interface. Returns the received class to allow chaining or saving the created loader.</td>
 					</tr>
 					<tr>
 						<th scope="row" class="py-2 align-baseline"><pre class="p-0"><code class="language-typescript">open(opener: HTMLElement | SVGElement | null, event?: Event): void</code></pre></th>

--- a/src/PdModal.tsx
+++ b/src/PdModal.tsx
@@ -138,12 +138,14 @@ export class PdModal extends EventTarget {
 		this.window.addEventListener('click', this.delegateWindowClick.bind(this))
 	}
 
-	public registerContentLoader(contentLoader: ContentLoader): void {
+	public registerContentLoader(contentLoader: ContentLoader): ContentLoader {
 		this.contentLoaders.push(contentLoader)
 
 		if (this.options.autoBind && contentLoader.autoBind) {
 			contentLoader.autoBind()
 		}
+
+		return contentLoader
 	}
 
 	public open(opener: PdModalOpener, event?: Event): void {


### PR DESCRIPTION
The `registercontentLoader` method now returns passed `ContentLoader` making it easier to chain calls or actually save the created loader.