### PR TITLE
feature: Thumbnail link has a special class when the target is iframe

### DIFF
--- a/src/contentLoaders/MediaGalleryContentLoader.tsx
+++ b/src/contentLoaders/MediaGalleryContentLoader.tsx
@@ -174,7 +174,10 @@ export class MediaGalleryContentLoader extends BaseContentLoader implements Cont
 			const thumbnail = (
 				<a
 					href={opener.href}
-					class="pd-modal__thumbnail-link"
+					class={[
+						'pd-modal__thumbnail-link',
+						opener.dataset.modalIframe !== undefined ? 'pd-modal__thumbnail-link--iframe' : false
+					]}
 					data-index={index}
 					aria-label={`${text.showImage} ${this.getPagesSummaryText(index + 1)}`}
 				>


### PR DESCRIPTION
When the thubmnail link targets iframe instead of image, the `pd-modal__thumbnail-link--iframe` class is added to the link.