### PR TITLE
feature: Add class names to modal elements via data attributes

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -464,6 +464,8 @@ modal.registerContentLoader(new HTMLContentLoader(modal))</code></pre>
 		</ul>
 		<p>Using <code>data-modal-related</code> you can link multiple media together. When this happens, the pager is shown. When you want to load e.g. YouTube video, you have to use <code>data-modal-iframe</code> &ndash; this attribute is necessary whenever <code>iframe</code> should be used. Otherwise, the <code>img</code> element will be used. Using <code>data-modal-media</code> is optional when other matcher condition is evaluated as truthy.</p>
 
+		<p>The class names of certain elements can be added using data attributes on the opening element. The <code>data-modal-thumbnail-link-class-name</code> would add a class name to the thumbnail link, while the <code>data-modal-iframe-class-name</code> would add a class name to the iframe element (when <code>data-modal-iframe="true"</code> is used).</p>
+
 		<h4>Options</h4>
 		<div class="!max-w-full overflow-x-auto">
 			<table class="min-w-[900px]">

--- a/src/contentLoaders/MediaGalleryContentLoader.tsx
+++ b/src/contentLoaders/MediaGalleryContentLoader.tsx
@@ -176,7 +176,8 @@ export class MediaGalleryContentLoader extends BaseContentLoader implements Cont
 					href={opener.href}
 					class={[
 						'pd-modal__thumbnail-link',
-						opener.dataset.modalIframe !== undefined ? 'pd-modal__thumbnail-link--iframe' : false
+						opener.dataset.modalIframe !== undefined ? 'pd-modal__thumbnail-link--iframe' : false,
+						opener.dataset.modalThumbnailLinkClassName
 					]}
 					data-index={index}
 					aria-label={`${text.showImage} ${this.getPagesSummaryText(index + 1)}`}
@@ -453,7 +454,7 @@ export class MediaGalleryContentLoader extends BaseContentLoader implements Cont
 		mediaElement.classList.add('pd-modal__media')
 
 		if (isIframe) {
-			this.setIframeAttributes(mediaElement as HTMLIFrameElement, modal)
+			this.setIframeAttributes(mediaElement as HTMLIFrameElement, modal, opener)
 		} else {
 			this.setImageAttributes(mediaElement as HTMLImageElement, modal, opener, title)
 		}
@@ -461,10 +462,14 @@ export class MediaGalleryContentLoader extends BaseContentLoader implements Cont
 		return mediaBoxElement
 	}
 
-	private setIframeAttributes(iframe: HTMLIFrameElement, modal: PdModal): void {
+	private setIframeAttributes(iframe: HTMLIFrameElement, modal: PdModal, opener: HTMLAnchorElement): void {
 		const width = parseFloat(getComputedStyle(modal.content).width)
 
 		iframe.classList.add('pd-modal__media--iframe')
+
+		if (opener.dataset.modalIframeClassName) {
+			iframe.classList.add(opener.dataset.modalIframeClassName)
+		}
 
 		iframe.allowFullscreen = true
 		iframe.width = String(width)


### PR DESCRIPTION
The class names of certain elements can now be added using data attributes on the opening element. The `data-modal-thumbnail-link-class-name` would add a class name to the thumbnail link, while the `data-modal-iframe-class-name` would add a class name to the iframe element (when `data-modal-iframe="true"` is used).