### PR TITLE
feature: Content loader always has `classList` and `listeners` properties defined

### DIFF
--- a/src/PdModal.tsx
+++ b/src/PdModal.tsx
@@ -20,8 +20,8 @@ export type I18nEntry = {
 }
 
 export interface ContentLoader {
-	classList?: string[]
-	listeners?: ContentLoaderListener<keyof HTMLElementEventMap>[]
+	classList: string[]
+	listeners: ContentLoaderListener<keyof HTMLElementEventMap>[]
 	matcher: (opener: PdModalOpener) => boolean
 	isAsync: (opener: PdModalOpener) => boolean
 	openContent: (opener: PdModalOpener) => boolean
@@ -420,7 +420,7 @@ export class PdModal extends EventTarget {
 	private setClassListFromContentLoader(contentLoader: ContentLoader): void {
 		this.removeClassListFromPreviousContentLoader()
 
-		if (contentLoader.classList) {
+		if (contentLoader.classList.length) {
 			this.loaderClassList = contentLoader.classList
 			this.element.classList.add(...contentLoader.classList)
 		}
@@ -429,7 +429,7 @@ export class PdModal extends EventTarget {
 	private setListenersFromContentLoader(contentLoader: ContentLoader): void {
 		this.removeListenersFromPreviousContentLoader()
 
-		contentLoader.listeners?.forEach((contentLoaderListener) => {
+		contentLoader.listeners.forEach((contentLoaderListener) => {
 			this.element.addEventListener(contentLoaderListener.eventName, contentLoaderListener.listener)
 			this.loaderListeners.push(contentLoaderListener)
 		})

--- a/src/contentLoaders/BaseContentLoader.ts
+++ b/src/contentLoaders/BaseContentLoader.ts
@@ -1,6 +1,9 @@
-import { PdModal } from '../PdModal'
+import { ContentLoaderListener, PdModal } from '../PdModal'
 
 export class BaseContentLoader {
+	public classList: string[] = []
+	public listeners: ContentLoaderListener<any>[] = []
+
 	protected modal: PdModal
 
 	public constructor(modal: PdModal) {

--- a/src/contentLoaders/MediaGalleryContentLoader.tsx
+++ b/src/contentLoaders/MediaGalleryContentLoader.tsx
@@ -51,8 +51,6 @@ export class MediaGalleryContentLoader extends BaseContentLoader implements Cont
 	// is removed in the `openContent` method.
 	public classList: string[] = ['pd-modal--media', 'pd-modal--has-thumbnail-list']
 
-	public listeners: ContentLoaderListener<any>[] = []
-
 	public readonly i18n: Record<string, I18nMediaGalleryEntry> = {
 		en: { prev: 'Previous image', next: 'Next image', showImage: 'Show image', imageOf: 'of' },
 		de: { prev: 'Vorheriges Bild', next: 'Nächstes Bild', showImage: 'Bild anzeigen', imageOf: 'von' },


### PR DESCRIPTION
ContentLoader classes will now always have the `classList` and `listeners` properties defined. This allows users to further extend there properties without needing to create a new custom loader. The default values for these properties are either an empty array or retain their previous values if they were already set for certain loaders.