### PR TITLE
chore: Move `@peckadesign/pd-naja` to `optionalDependencies` and loosen version constraint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "2.9.0",
 			"license": "MIT",
 			"dependencies": {
-				"@peckadesign/pd-naja": "^1.1.0",
 				"a11y-dialog": "^8.1.4",
 				"jsx-dom": "^8.0.5"
 			},
@@ -26,6 +25,9 @@
 				"rollup": "^4.52.5",
 				"typescript": "^5.9.3",
 				"typescript-eslint": "^8.43.0"
+			},
+			"optionalDependencies": {
+				"@peckadesign/pd-naja": ">=1.1.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -297,6 +299,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
 			"integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
 			"license": "MIT",
+			"optional": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -671,6 +674,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@peckadesign/pd-naja/-/pd-naja-1.1.0.tgz",
 			"integrity": "sha512-qwEU0kWxb2cj9cmzFQUYjLxuxnYZyvS53VULuIXIboPaRVSJk3GK1jBfsa7wCNr5ZxAseY+6JQVWo9synK6/FA==",
+			"optional": true,
 			"dependencies": {
 				"naja": "^2.5.0"
 			}
@@ -2455,6 +2459,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/naja/-/naja-2.5.0.tgz",
 			"integrity": "sha512-SmGR5VVVtF7jF6EPRkPx+cuhzsxDvKKbs+XO8RO2/2En2l2PBe9LglwFBbYIWMLxeGuYl5wGt2MQvkUjjVaagg==",
+			"optional": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3"
 			}
@@ -3488,7 +3493,8 @@
 		"@babel/runtime": {
 			"version": "7.27.6",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-			"integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q=="
+			"integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+			"optional": true
 		},
 		"@babel/template": {
 			"version": "7.27.2",
@@ -3751,6 +3757,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@peckadesign/pd-naja/-/pd-naja-1.1.0.tgz",
 			"integrity": "sha512-qwEU0kWxb2cj9cmzFQUYjLxuxnYZyvS53VULuIXIboPaRVSJk3GK1jBfsa7wCNr5ZxAseY+6JQVWo9synK6/FA==",
+			"optional": true,
 			"requires": {
 				"naja": "^2.5.0"
 			}
@@ -4871,6 +4878,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/naja/-/naja-2.5.0.tgz",
 			"integrity": "sha512-SmGR5VVVtF7jF6EPRkPx+cuhzsxDvKKbs+XO8RO2/2En2l2PBe9LglwFBbYIWMLxeGuYl5wGt2MQvkUjjVaagg==",
+			"optional": true,
 			"requires": {
 				"@babel/runtime": "^7.18.3"
 			}

--- a/package.json
+++ b/package.json
@@ -28,16 +28,18 @@
 		"url": "https://github.com/peckadesign/pd-modal/issues"
 	},
 	"homepage": "https://github.com/peckadesign/pd-modal#readme",
-	"dependencies": {
-		"@peckadesign/pd-naja": "^1.1.0",
-		"a11y-dialog": "^8.1.4",
-		"jsx-dom": "^8.0.5"
-	},
 	"scripts": {
 		"build": "NODE_ENV=production rollup -c --bundleConfigAsCjs",
 		"lint": "NODE_ENV=development eslint src --ext .ts --max-warnings=0"
 	},
 	"sideEffects": false,
+	"dependencies": {
+		"a11y-dialog": "^8.1.4",
+		"jsx-dom": "^8.0.5"
+	},
+	"optionalDependencies": {
+		"@peckadesign/pd-naja": ">=1.1.0"
+	},
 	"devDependencies": {
 		"@rollup/plugin-babel": "^6.1.0",
 		"@rollup/plugin-commonjs": "^28.0.9",


### PR DESCRIPTION
- Moved `@peckadesign/pd-naja` to `optionalDependencies`, as it’s not required for the package to function.
- Relaxed version constraint to allow newer compatible versions.