### PR TITLE
fix: Correct `event.preventDefault()` call in `autoBind`

### DIFF
--- a/src/contentLoaders/HTMLContentLoader.ts
+++ b/src/contentLoaders/HTMLContentLoader.ts
@@ -44,7 +44,7 @@ export class HTMLContentLoader extends BaseContentLoader implements ContentLoade
 				return
 			}
 
-			if (element instanceof HTMLAnchorElement) {
+			if (opener instanceof HTMLAnchorElement) {
 				event.preventDefault()
 			}
 


### PR DESCRIPTION
In release 2.9.0, the `event.preventDefault()` call was changed to run only when clicking an anchor element. However, the wrong variable was checked to determine whether the target is an anchor. Instead of checking `element` (`event.target`), we must check the actual `opener` element, because the clicked anchor may contain nested elements (for example `img`, `span`, etc.).