### PR TITLE
fix: `resetContent` method to clear snippets after modal close

### DIFF
--- a/src/PdModalNajaAdapter.ts
+++ b/src/PdModalNajaAdapter.ts
@@ -21,6 +21,8 @@ export class PdModalNajaAdapter implements AjaxModal {
 
 		this.element = pdModal.element
 		this.reservedSnippetIds = reservedSnippetIds
+
+		this.pdModal.addEventListener('afterClose', this.resetContent.bind(this))
 	}
 
 	public show(opener: Element, options: PdModalAjaxOptions, event: Event): void {
@@ -70,6 +72,19 @@ export class PdModalNajaAdapter implements AjaxModal {
 			width: this.getWidth(element),
 			className: this.getClassName(element)
 		}
+	}
+
+	public resetContent(): void {
+		const snippets = this.pdModal.element.querySelectorAll<HTMLElement>(`#${this.reservedSnippetIds.join(', #')}`)
+
+		snippets.forEach((snippet: HTMLElement) => {
+			// Title and content are reset by PdModal itself
+			if (snippet === this.pdModal.title || snippet === this.pdModal.content) {
+				return
+			}
+
+			snippet.replaceChildren()
+		})
 	}
 
 	public setOptions(): void {


### PR DESCRIPTION
Introduced a resetContent method to clear child elements of unused modal snippets after the modal closes. Without this reset, opening a second AJAX modal could leave behind content from snippets of the previously opened modal (except for the title and main content).