### PR TITLE
ci: Bind GitHub release draft to tag via `gh release create`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,20 +47,20 @@ jobs:
           path: dist/
 
       - name: Create release draft 🕊️
-        uses: softprops/action-gh-release@v2
-        with:
-          draft: true
-          files: |
-            dist/PdModal.esm.js
-            dist/PdModal.esm.js.map
-            dist/PdModal.js
-            dist/PdModal.js.map
-            dist/PdModal.min.js
-            dist/PdModal.min.js.map
-            dist/PdModalNajaAdapter.js
-            dist/PdModalNajaAdapter.js.map
-            dist/PdModalNajaAdapter.min.js
+        run: |
+          gh release create "${{ github.ref_name }}" --draft --target "${{ github.sha }}" \
+            dist/PdModal.esm.js \
+            dist/PdModal.esm.js.map \
+            dist/PdModal.js \
+            dist/PdModal.js.map \
+            dist/PdModal.min.js \
+            dist/PdModal.min.js.map \
+            dist/PdModalNajaAdapter.js \
+            dist/PdModalNajaAdapter.js.map \
+            dist/PdModalNajaAdapter.min.js \
             dist/PdModalNajaAdapter.min.js.map
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publishPublic:
     name: Publish (public)


### PR DESCRIPTION
## Summary

- 🛠️ Replace `softprops/action-gh-release@v2` with `gh release create "${{ github.ref_name }}" --draft --target "${{ github.sha }}"` in `publish.yml`

## Why

Previously the draft release got created with an `untagged-<hash>` placeholder slug instead of being bound to the actual pushed tag. The tag had to be manually re-selected in the GitHub UI before publishing.

Switching to `gh release create` with explicit `tag_name` (via `github.ref_name`) binds the draft to the real tag from the start. Mirrors the fix already applied to `prettier-plugin-latte-tailwind` and `pd-naja` (PR #53).

## Test plan

- [ ] Merge & verify CI passes
- [ ] Next release: confirm draft URL appears as `releases/tag/<version>` directly (no `untagged-` slug)
- [ ] Confirm all `dist/PdModal*` files are still attached to the draft