### PR TITLE
fix: Prevent default action on a11y-dialog closers

### DIFF
--- a/src/PdModal.tsx
+++ b/src/PdModal.tsx
@@ -133,6 +133,7 @@ export class PdModal extends EventTarget {
 		this.a11yDialog.on('hide', this.dialogOnHide.bind(this))
 
 		this.window.addEventListener('click', this.delegateWindowClick.bind(this))
+		this.element.addEventListener('click', this.preventCloserDefault.bind(this), true)
 	}
 
 	public registerContentLoader(contentLoader: ContentLoader): ContentLoader {
@@ -453,6 +454,21 @@ export class PdModal extends EventTarget {
 	private delegateWindowClick(event: Event): void {
 		if (event.target === this.window) {
 			this.overlay.click()
+		}
+	}
+
+	// a11y-dialog v8 delegates closer clicks (capture, on document) and calls hide(), but never calls
+	// preventDefault(). A closer that is a link or a submit control would still perform its default action
+	// (navigation / form submit) on top of closing. We restore the pre-v8 behavior by cancelling the default action
+	// for any closer. Registered in the capture phase so it runs while the modal element is still on the event's
+	// propagation path, regardless of when a11y-dialog detaches the element.
+	private preventCloserDefault(event: Event): void {
+		if (!(event.target instanceof Element)) {
+			return
+		}
+
+		if (event.target.closest(this.a11yDialogCloserSelector)) {
+			event.preventDefault()
 		}
 	}
 


### PR DESCRIPTION
Closer links and submit controls stopped having their default action cancelled since 2.9.0.

- a11y-dialog v8 delegates closer clicks on `document` (capture) and calls `hide()`, but never calls `preventDefault()`. A closer that is an `<a href>` or a submit control therefore closed the modal **and** performed its default action (navigation / form submit).
- Restores the pre-v8 behavior via a single delegated `click` listener on `this.element`, registered in the **capture** phase, that calls `preventDefault()` for any `[data-a11y-dialog-hide]` closer.
- No return to per-closer tracking — keeps the benefit of `ea0bbfb` (no add/remove of listeners on every content load).

Affected versions: 2.9.0–2.10.2.